### PR TITLE
chore: move to circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       - image: marionebl/move_rs_dev
     working_directory: /home/rust/src
     steps:
-      - checkout
+      - checkout:
           path: /home/rust/repo
       - run:
           name: Mount sources

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,11 @@
+version: 2
+jobs:
+  test:
+    docker:
+      - image: marionebl/move_rs_dev
+    working_directory: /home/rust/src
+    steps:
+      - checkout
+      - run:
+          name: Test
+          command: cargo test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  test:
+  build:
     docker:
       - image: marionebl/move_rs_dev
     working_directory: /home/rust/src

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
           path: /home/rust/repo
       - run:
           name: Mount sources
-          command: cp -r /home/rust/repo/* .
+          command: cp -r /home/rust/repo/src /home/rust/repo/static /home/rust/repo/tests . 
       - run:
           name: Test
           command: cargo test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,10 @@ jobs:
     working_directory: /home/rust/src
     steps:
       - checkout
+          path: /home/rust/repo
+      - run:
+          name: Mount sources
+          command: cp -r /home/rust/repo/* .
       - run:
           name: Test
           command: cargo test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: rust
-cache: cargo
-rust:
-  - nightly

--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@
 cp .env.sample .env
 docker pull marionebl/move_rs_dev
 docker-compose build
-docker-compose run move_rs run # binds to port 1337
+docker-compose run move_rs run # binds to port 8000
 ```


### PR DESCRIPTION
Brings down testing times to approx. 1 minute.
Approx. 75% are spent pulling the docker image. 